### PR TITLE
Googleアカウントからカレンダー情報を取得

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -12,7 +12,8 @@
   "oauthScopes": [
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/script.projects"
+    "https://www.googleapis.com/auth/script.projects",
+    "https://www.googleapis.com/auth/calendar"
   ],
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",

--- a/frontend/pages/sync.html
+++ b/frontend/pages/sync.html
@@ -11,19 +11,41 @@
         <!-- ここに画面固有のコンテンツを追加 -->
         
         <div class="content-section">
-            <ul id="calendar-list"></ul>
+            <div class="calendar-selector">
+              <label for="calendar-select">同期先カレンダーを選択:</label>
+              <select id="calendar-select"></select>
+            </div>
+            <div id="calendar-info"></div>
         </div>
     </div>
+
     <script>
       window.addEventListener('DOMContentLoaded', function() {
         google.script.run
           .withSuccessHandler(function(calendars) {
-            // カレンダー一覧を #calendar-list に表示
-            const list = document.getElementById('calendar-list');
-            if (list && calendars) {
-              list.innerHTML = calendars.map(c =>
-                `<li>${c.summary} (${c.id})</li>`
+            const select = document.getElementById('calendar-select');
+            const info = document.getElementById('calendar-info');
+            if (select && calendars) {
+              // optionを追加
+              select.innerHTML = calendars.map((c, i) =>
+                `<option value="${i}">${c.summary}</option>`
               ).join('');
+              // 初期表示
+              showInfo(0);
+              // 選択変更時
+              select.addEventListener('change', function() {
+                showInfo(this.value);
+              });
+            }
+            function showInfo(idx) {
+              const c = calendars[idx];
+              info.innerHTML = `
+                <div>
+                  <strong>カレンダー名:</strong> ${c.summary}<br>
+                  <strong>ID:</strong> ${c.id}<br>
+                  <strong>説明:</strong> ${c.description || '-'}
+                </div>
+              `;
             }
           })
           .getGoogleCalendars();

--- a/frontend/pages/sync.html
+++ b/frontend/pages/sync.html
@@ -11,8 +11,22 @@
         <!-- ここに画面固有のコンテンツを追加 -->
         
         <div class="content-section">
-            <h2>セクション1</h2>
-            <p>コンテンツ</p>
+            <ul id="calendar-list"></ul>
         </div>
     </div>
+    <script>
+      window.addEventListener('DOMContentLoaded', function() {
+        google.script.run
+          .withSuccessHandler(function(calendars) {
+            // カレンダー一覧を #calendar-list に表示
+            const list = document.getElementById('calendar-list');
+            if (list && calendars) {
+              list.innerHTML = calendars.map(c =>
+                `<li>${c.summary} (${c.id})</li>`
+              ).join('');
+            }
+          })
+          .getGoogleCalendars();
+      });
+    </script>
 </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,10 @@
  */
 
 import { convertSpreadsheetToJson, getSpreadsheetInfo } from './converters/spreadsheet-to-json.js';
+import { getGoogleCalendars } from './webapp/google-calendar-api.js';
+
+// @ts-ignore
+globalThis.getGoogleCalendars = getGoogleCalendars;
 
 function doGet(): GoogleAppsScript.HTML.HtmlOutput {
   const htmlOutput = HtmlService.createTemplateFromFile('index');

--- a/src/webapp/google-calendar-api.ts
+++ b/src/webapp/google-calendar-api.ts
@@ -1,0 +1,20 @@
+/**
+ * Googleカレンダー一覧を返す（ダミー）
+ * @return {Array<Object>} カレンダー情報の配列
+ */
+export function getGoogleCalendars() {
+  return [
+    {
+      id: "primary",
+      summary: "自分のカレンダー",
+      description: "メインのカレンダー",
+      backgroundColor: "#9a9cff"
+    },
+    {
+      id: "abcdef123456@group.calendar.google.com",
+      summary: "会社の予定",
+      description: "",
+      backgroundColor: "#ff7537"
+    }
+  ];
+} 

--- a/src/webapp/google-calendar-api.ts
+++ b/src/webapp/google-calendar-api.ts
@@ -1,20 +1,13 @@
 /**
- * Googleカレンダー一覧を返す（ダミー）
+ * Googleカレンダー一覧を返す（実データ版）
  * @return {Array<Object>} カレンダー情報の配列
  */
 export function getGoogleCalendars() {
-  return [
-    {
-      id: "primary",
-      summary: "自分のカレンダー",
-      description: "メインのカレンダー",
-      backgroundColor: "#9a9cff"
-    },
-    {
-      id: "abcdef123456@group.calendar.google.com",
-      summary: "会社の予定",
-      description: "",
-      backgroundColor: "#ff7537"
-    }
-  ];
+  const calendars = CalendarApp.getAllCalendars();
+  return calendars.map(cal => ({
+    id: cal.getId(),
+    summary: cal.getName(),
+    description: cal.getDescription(),
+    backgroundColor: "#9a9cff" // CalendarAppでは色は取得できないためダミー
+  }));
 } 


### PR DESCRIPTION
## 概要

Googleカレンダー選択画面のカレンダー一覧取得・選択UIの実装。  
GASバックエンドで実際のGoogleカレンダー一覧を取得し、フロントエンドでセレクトボックスとして表示・選択内容を詳細表示できるようにしました。

## 関連タスク
Close #6

## やったこと

- GAS側で `getGoogleCalendars` を `CalendarApp` を用いて実装
- 必要なOAuthスコープ（calendar）を `appsscript.json` に追加
- `src/main.ts` で `getGoogleCalendars` をグローバル関数として登録
- `frontend/pages/sync.html` にカレンダー選択セレクトボックスと選択内容の詳細表示を追加
- 取得したカレンダー一覧をセレクトボックスに展開し、選択変更時にカレンダー情報を下部に表示

## やらないこと

- カレンダー色や共有カレンダーの詳細取得（必要に応じてAdvanced Calendar API対応は今後検討）
- 同期内容サマリーや注意事項セクションの実装
- カレンダー選択以外のUI/ロジック

## レビュー事項

- GASの権限設定（`appsscript.json` のスコープ追加）が正しいか
- フロントエンドからカレンダー一覧が正しく取得・表示できるか
- コード分割・グローバル関数登録の方法が適切か

## 補足 参考情報

- [Google Calendar API の概要（公式ドキュメント）](https://developers.google.com/workspace/calendar/api/guides/overview?hl=ja)
- 今回は `CalendarApp` のみ利用、色はダミー値で対応